### PR TITLE
docs(claude): document mutations, fix auto-close note, add main-pr-strategy

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,6 +19,7 @@ You are assisting with the AI Integration work on the OET fork of `pypsa-app`. O
 | `.claude/project/branching.md` | Branch naming rules, upstream sync procedure |
 | `.claude/project/issue-workflow.md` | Pick-up → implement → PR → merge, and how each step updates the Project |
 | `.claude/project/sprint-workflow.md` | How to plan, assign, and close a sprint |
+| `.claude/project/main-pr-strategy.md` | Two-PR split for promotions to `main`; the curated list of "never on main" and "split into a separate PR" paths |
 | `.claude/commands/pick-up.md` | `/pick-up <issue#>` — branch + mark In Progress |
 | `.claude/commands/ship.md` | `/ship` — open PR, mark In Review |
 | `.claude/commands/sync-upstream.md` | `/sync-upstream` — fetch from `PyPSA/pypsa-app`, fast-forward `main`, merge into `dev-llm-implementation` |

--- a/.claude/commands/sync-upstream.md
+++ b/.claude/commands/sync-upstream.md
@@ -28,9 +28,9 @@ Steps:
    ```
    `.claude/` should survive untouched because it only exists on this branch.
 
-4. Verify `.claude/` did NOT get introduced on `main`:
+4. Verify Category A paths (see `.claude/project/main-pr-strategy.md`) did NOT get introduced on `main`:
    ```
-   git ls-tree main -- .claude
+   git ls-tree main -- .claude .sandcastle CLAUDE.md AGENTS.md
    ```
    Output must be empty. If not, revert the offending commit on `main` before pushing.
 

--- a/.claude/project/github-project.md
+++ b/.claude/project/github-project.md
@@ -47,13 +47,15 @@ Fetch fresh when needed — new iterations get generated; list at:
 gh api graphql -f query='query { node(id: "PVTIF_lADOB88FCc4BVUZizhQxA1Y") { ... on ProjectV2IterationField { configuration { iterations { id title startDate } } } } }'
 ```
 
-Current as of 2026-04-21:
+Current as of 2026-05-12:
 
 | Sprint | ID | Dates |
 |---|---|---|
-| Sprint 1 (current) | `9afed504` | Apr 21 – May 4, 2026 |
-| Sprint 2 (planned) | `09bf05b9` | May 5 – May 18, 2026 |
+| Sprint 1 (archived) | `9afed504` | Apr 21 – May 4, 2026 |
+| Sprint 2 (current) | `09bf05b9` | May 5 – May 18, 2026 |
 | Sprint 3 (planned) | `29859a5e` | May 19 – Jun 1, 2026 |
+
+Past iterations drop out of the live `iterations` array once they end; only current + upcoming are returned. Use `completedIterations { ... }` on the `IterationFieldConfiguration` if you need archived IDs.
 
 ## Views
 
@@ -94,4 +96,60 @@ gh issue create -R open-energy-transition/pypsa-app --title "..." --body-file ..
 # 2. Add to the project
 ISSUE_NODE=$(gh api /repos/open-energy-transition/pypsa-app/issues/N --jq '.node_id')
 gh api graphql -f query="mutation { addProjectV2ItemById(input: {projectId: \"PVT_kwDOB88FCc4BVUZi\", contentId: \"$ISSUE_NODE\"}) { item { id } } }"
+```
+
+## Useful project-item mutations
+
+### Remove an item from the board (descope without deleting the issue)
+
+Closed-as-not-planned issues should be removed from the board so they don't clutter active views. The issue itself stays closed on the repo.
+
+```
+gh api graphql -f query='mutation { deleteProjectV2Item(input: { projectId: "PVT_kwDOB88FCc4BVUZi", itemId: "<ITEM_ID>" }) { deletedItemId } }'
+```
+
+### Reorder items globally (default sort across all views)
+
+`updateProjectV2ItemPosition` sets the project's default item order. Views without their own sort/group config inherit this order — including the `ROADMAP_LAYOUT` "Sprint Gantt" view. Use `afterId: null` to place an item at the top; otherwise pass the id of the item it should follow.
+
+```
+# Place ITEM at the top
+gh api graphql -f query='mutation { updateProjectV2ItemPosition(input: { projectId: "PVT_kwDOB88FCc4BVUZi", itemId: "<ITEM>", afterId: null }) { items { totalCount } } }'
+
+# Stack a list of items in a defined order
+ORDER=( <item_id_1> <item_id_2> ... )
+prev="null"
+for item in "${ORDER[@]}"; do
+  AFTER=$([ "$prev" = "null" ] && echo 'afterId:null' || echo "afterId:\"$prev\"")
+  gh api graphql -f query="mutation { updateProjectV2ItemPosition(input: { projectId: \"PVT_kwDOB88FCc4BVUZi\", itemId: \"$item\", $AFTER }) { items { totalCount } } }" >/dev/null
+  prev="$item"
+done
+```
+
+Per-view sort settings in the UI override the project default — a view with its own sort won't respect this reordering. Check `sortByFields` / `groupByFields` on a view if items don't move where expected:
+
+```
+gh api graphql -f query='query { node(id: "<VIEW_ID>") { ... on ProjectV2View { name layout filter sortByFields(first: 5) { nodes { direction field { ... on ProjectV2FieldCommon { name } } } } groupByFields(first: 5) { nodes { ... on ProjectV2FieldCommon { name } } } } } }'
+```
+
+## Whole-board audit query
+
+Single query returning every item with all relevant fields — useful for verifying convention consistency in one shot.
+
+```
+gh api graphql -f query='query {
+  organization(login: "open-energy-transition") {
+    projectV2(number: 73) {
+      items(first: 50) { nodes {
+        content { ... on Issue { number title state milestone { title } labels(first: 10) { nodes { name } } } }
+        status:   fieldValueByName(name: "Status")   { ... on ProjectV2ItemFieldSingleSelectValue { name } }
+        priority: fieldValueByName(name: "Priority") { ... on ProjectV2ItemFieldSingleSelectValue { name } }
+        estimate: fieldValueByName(name: "Estimate") { ... on ProjectV2ItemFieldNumberValue { number } }
+        sprint:   fieldValueByName(name: "Sprint")   { ... on ProjectV2ItemFieldIterationValue { title } }
+      } }
+    }
+  }
+}' --jq '.data.organization.projectV2.items.nodes[]
+| "#\(.content.number)\t\(.content.state[0:1])\t\(.status.name // "—")\t\(.priority.name // "—")\t\(.estimate.number // "—")\t\(.sprint.title // "—")\t\(.content.milestone.title // "—")\t\(.content.title)"' \
+| column -t -s$'\t' -N "ISS,ST,STATUS,P,E,SPRINT,MILESTONE,TITLE"
 ```

--- a/.claude/project/issue-workflow.md
+++ b/.claude/project/issue-workflow.md
@@ -11,7 +11,7 @@ Each issue transits through this lifecycle. The Status field on the GH Project i
 | In Progress | Branch created from `dev-llm-implementation` | PR opened |
 | In Review | PR opened against `dev-llm-implementation` | PR merged / closed |
 | Blocked | Depends on external thing | Dependency resolved |
-| Done | PR merged (issue auto-closes via `Closes #N`) | — |
+| Done | PR merged + issue manually closed (see *Shipping an issue*) | — |
 
 ## Setting status via GraphQL
 
@@ -49,8 +49,19 @@ gh api graphql -f query="query { repository(owner: \"open-energy-transition\", n
 2. Push the branch, open a PR against `dev-llm-implementation` with `Closes #<N>` in the body.
 3. Set Status = `In Review` (option id `4f2e3ecb`).
 4. Request review (or self-merge for solo work — team norms TBD).
-5. After merge, the issue auto-closes. Status on the project will read as `Done` only if you also set it — do so after merge.
+5. After merge:
+   - **Manually close the linked issue** — `gh issue close <N> --reason completed`. The `Closes #N` keyword only auto-closes issues when the PR's base is the repository's *default branch* (`main`). PRs merged into `dev-llm-implementation` do not trigger auto-close.
+   - Set Status = `Done` on the project item (option id `7844fc97`).
 
 ## Blocking
 
 Set Status = `Blocked` (option id `2b60f3e1`) and add a comment on the issue explaining the dependency. Unblock by flipping back to the previous status when the dependency clears.
+
+## Scoping out / wontfix
+
+For an issue that won't ship:
+
+1. `gh issue close <N> --reason "not planned"` — marks the issue closed with the *not planned* state-reason (distinct from a normal "completed" close).
+2. Remove it from the project board so it doesn't linger in active views — use `deleteProjectV2Item` (see `github-project.md` → *Useful project-item mutations*). The issue itself stays on the repo for history.
+
+Setting Status = `Done` for a not-planned issue is misleading — the board's Done column should mean shipped, not abandoned.

--- a/.claude/project/main-pr-strategy.md
+++ b/.claude/project/main-pr-strategy.md
@@ -1,0 +1,120 @@
+# Promoting `dev-llm-implementation` → `main`
+
+Two distinct categories of paths get special handling when opening a PR against `main`. Keep the lists below in sync with reality before every promotion PR (see *Audit* at the bottom).
+
+## Category A — Never on `main` (hard rule)
+
+These exist only on `dev-llm-implementation` and derivative branches. They give an LLM assistant project context but are noise for everyone else.
+
+| Path | Reason |
+|---|---|
+| `.claude/` | AI-assistant project context, commands, specs |
+| `.sandcastle/` | Sandcastle agent scratch space |
+| `CLAUDE.md` (root) | Top-level AI-assistant instructions |
+| `AGENTS.md` (root) | Top-level AI-agent instructions |
+
+Defensive backstop: `.claude` is already in `.gitignore`. Re-adding any of these by accident will not error, so the discipline matters more than the gitignore.
+
+The `sync-upstream.md` command verifies `.claude/` is absent on `main` after every upstream sync; extend that check if you add categories here.
+
+### Git pathspec (copy-pasteable)
+
+```
+':(exclude).claude/**'
+':(exclude).sandcastle/**'
+':(exclude)CLAUDE.md'
+':(exclude)AGENTS.md'
+```
+
+## Category B — Split into a separate PR (visual-clutter rule)
+
+These belong on `main` (deterministic builds need lockfiles; CI on `main` needs tests) but inflate the diff and make code review harder. **Open two stacked PRs**: the first ships only the real codebase, the second adds the surrounding files.
+
+| Path | Reason |
+|---|---|
+| `tests/**` | Test suites (Python pytest, e2e harness) |
+| `**/*.test.{ts,tsx,js,jsx}` | Vitest co-located component tests |
+| `**/*.spec.{ts,tsx,js,jsx}` | Playwright / other co-located specs |
+| `**/vitest.config.{ts,js}` | Vitest tooling config |
+| `uv.lock` | Python deps lock |
+| `package-lock.json` (root) | npm lock at repo root |
+| `frontend/app/package-lock.json` | npm lock for the frontend SPA |
+
+### Git pathspec (copy-pasteable)
+
+```
+':(exclude)tests/**'
+':(exclude)**/*.test.ts' ':(exclude)**/*.test.tsx' ':(exclude)**/*.test.js' ':(exclude)**/*.test.jsx'
+':(exclude)**/*.spec.ts' ':(exclude)**/*.spec.tsx' ':(exclude)**/*.spec.js' ':(exclude)**/*.spec.jsx'
+':(exclude)**/vitest.config.ts' ':(exclude)**/vitest.config.js'
+':(exclude)uv.lock'
+':(exclude)package-lock.json'
+':(exclude)frontend/app/package-lock.json'
+```
+
+## The two-PR split — workflow
+
+When `dev-llm-implementation` is ready to promote to `main`:
+
+1. **PR 1 — "Codebase"**
+   - Branch from `main`. Apply files from `dev-llm-implementation` excluding **both** Category A and Category B.
+   - Reviewers see only production code, configs, and user-facing docs.
+
+2. **PR 2 — "Tests + lockfiles"** (stacked on PR 1)
+   - From PR 1's branch, apply the Category B paths from `dev-llm-implementation`.
+   - Lands tests and lockfiles aligned with the code from PR 1.
+   - Reviewers can collapse this PR's diff with `?w=1&hide=lockfiles` or just glance at file paths.
+
+Recipe (run on a fresh clone or worktree from `main`):
+
+```
+git fetch origin
+git checkout -b promote/codebase main
+
+# PR 1 source set = everything on dev except Category A and B
+git ls-tree -r dev-llm-implementation --name-only \
+  | grep -vE '^(\.claude/|\.sandcastle/|CLAUDE\.md$|AGENTS\.md$)' \
+  | grep -vE '^tests/' \
+  | grep -vE '\.test\.(ts|tsx|js|jsx)$' \
+  | grep -vE '\.spec\.(ts|tsx|js|jsx)$' \
+  | grep -vE '(^|/)vitest\.config\.(ts|js)$' \
+  | grep -vE '^(uv\.lock|package-lock\.json|frontend/app/package-lock\.json)$' \
+  > /tmp/codebase-paths.txt
+xargs -a /tmp/codebase-paths.txt git checkout dev-llm-implementation --
+git commit -m "feat: promote codebase from dev-llm-implementation"
+git push -u origin promote/codebase
+# Open PR 1 against main
+
+# PR 2 stacks on top, adds tests + lockfiles
+git checkout -b promote/tests-and-locks promote/codebase
+git checkout dev-llm-implementation -- tests/ uv.lock package-lock.json frontend/app/package-lock.json
+# Plus co-located *.test.* files:
+git ls-tree -r dev-llm-implementation --name-only | grep -E '\.test\.(ts|tsx|js|jsx)$' \
+  | xargs -r git checkout dev-llm-implementation --
+git commit -m "test+deps: bring tests and lockfiles aligned with the codebase PR"
+git push -u origin promote/tests-and-locks
+# Open PR 2 against main, base = promote/codebase (retargets to main once PR 1 merges)
+```
+
+## Audit — before every main PR
+
+Run this before promoting to catch new file types that should be in one of the lists above:
+
+```
+# What's NEW on dev-llm-implementation that main has never seen?
+git fetch origin
+git diff --name-only origin/main..origin/dev-llm-implementation \
+  | grep -vE '^(\.claude/|\.sandcastle/|tests/|CLAUDE\.md$|AGENTS\.md$)' \
+  | grep -vE '\.(test|spec)\.(ts|tsx|js|jsx)$' \
+  | grep -vE '(^|/)vitest\.config\.(ts|js)$' \
+  | grep -vE '^(uv\.lock|package-lock\.json|frontend/app/package-lock\.json)$'
+```
+
+Anything that comes out should be inspected:
+
+- A new generated artifact (e.g. snapshot files, fixtures over a size threshold) → consider adding to Category B.
+- A new AI/agent config (e.g. a new `.cursor/`, `.opencode/`, `MEMORY.md`) → add to Category A.
+- A new dependency lock (e.g. `pnpm-lock.yaml`, `poetry.lock`) → add to Category B.
+- Anything else → it belongs in the codebase PR, no action needed.
+
+Update both the table and the pathspec snippets in this file when you add anything.

--- a/.claude/project/sprint-workflow.md
+++ b/.claude/project/sprint-workflow.md
@@ -55,10 +55,19 @@ done
 
 ## Closing a sprint
 
-1. Review the Sprint view: move everything that shipped to `Status = Done`.
-2. Anything unfinished: either (a) move it to next sprint (set `Sprint = <next>`), or (b) push it back to `Backlog`.
+1. Review the Sprint view: move everything that shipped to `Status = Done` and close the issue (`gh issue close <N> --reason completed`).
+2. Anything unfinished: either (a) move it to next sprint (set `Sprint = <next>`) and flip `Status = Ready`, or (b) push it back to `Backlog` (clear the Sprint field). Don't leave open items tagged with the closed sprint — they break the `sprint:@current` filter.
 3. Write a brief retro as a comment on a tracking issue, OR in the project README (Settings → Short description).
 4. Create the next sprint iteration if it doesn't exist yet.
+
+### Sprint rollover audit
+
+After closing, sanity-check the board with the audit query in `github-project.md` and grep for inconsistencies:
+
+- Any issue with `state=OPEN` and `Sprint=<closed sprint>` → roll over to the next sprint or to Backlog.
+- Any closed-not-planned issue still on the board → `deleteProjectV2Item`.
+- Any `Status=Ready` on an issue without a Sprint → either schedule or push to Backlog.
+- Backlog issues tied to the active milestone whose work is starting → flip `Status=Ready` and set a Sprint.
 
 ## Velocity tracking
 


### PR DESCRIPTION
## Summary

Updates the `.claude/` context docs based on gaps discovered while harmonising project #73 this week. Docs-only, no code changes.

## What changes

### `.claude/project/github-project.md`
- Refresh Sprint iteration table — Sprint 2 is now the current iteration (2026-05-12).
- New **Useful project-item mutations** section covering:
  - `deleteProjectV2Item` — for removing scoped-out / not-planned issues from the board so they don't linger in active views.
  - `updateProjectV2ItemPosition` — sets the project's default item order; the `ROADMAP_LAYOUT` Sprint Gantt view inherits it.
- New whole-board audit query (single GraphQL request returning every item with status/priority/estimate/sprint/milestone/labels).

### `.claude/project/issue-workflow.md`
- Correct the auto-close claim. `Closes #N` only auto-closes the linked issue when the PR's base is the repository's *default branch*. PRs merged into `dev-llm-implementation` do not trigger auto-close — they need a manual `gh issue close <N> --reason completed`. The States table and Shipping section both updated.
- New **Scoping out / wontfix** subsection: `gh issue close --reason "not planned"` paired with `deleteProjectV2Item` to keep the board clean.

### `.claude/project/sprint-workflow.md`
- New **Sprint rollover audit** subsection listing the four inconsistencies to grep for after closing a sprint (open issues still tagged with the closed sprint, not-planned issues still on the board, etc.).

### `.claude/project/main-pr-strategy.md` (new)
When promoting `dev-llm-implementation` → `main`, two distinct rules apply:

- **Category A — never on main:** `.claude/`, `.sandcastle/`, root `CLAUDE.md`, `AGENTS.md`. Already convention via `.gitignore` + the `sync-upstream` check; this just formalises the list.
- **Category B — split into a separate PR:** `tests/**`, `**/*.test.*` / `**/*.spec.*`, `vitest.config.*`, `uv.lock`, `package-lock.json`, `frontend/app/package-lock.json`. These belong on `main` (deterministic builds need lockfiles; CI on `main` needs tests) but inflate review diffs by ~10k lines. The policy is two stacked PRs: codebase first, tests + lockfiles stacked on top.

The doc includes both lists with reasoning, copy-pasteable git pathspec snippets, the two-PR recipe (mirroring the `pr/llm-tools-refactor` + `pr/frontend-chat` stack from #27 / #28), and an audit command to surface new file types that should be added to either list.

### `.claude/CLAUDE.md`
- Added `main-pr-strategy.md` to the "What lives where" table so it's discoverable on session start.

### `.claude/commands/sync-upstream.md`
- Generalised the post-sync verification step from "`.claude/` did not get introduced on `main`" to "all Category A paths did not get introduced on `main`", with a pointer to `main-pr-strategy.md`.

## Test plan

- [ ] Review the new `main-pr-strategy.md` for accuracy of the path lists.
- [ ] Verify the audit query (last code block) returns nothing surprising when run today.
- [ ] Sanity-check `sync-upstream.md` step 4 still reads cleanly.

No runtime code touched; no tests to run.