### PR TITLE
chore: gitignore .pi/ agent workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ infra/
 AGENTS.md
 .mcp.json
 CLAUDE.md
+.pi/
 
 # IDEs
 .vscode/


### PR DESCRIPTION
## Summary

Adds `.pi/` to `.gitignore` so the agent workspace directory (skills + prompts loaded into Claude/pi-style assistants) is treated the same as `.claude/` and `AGENTS.md` — local-only, never committed.

## Why

`.pi/` already exists locally and now hosts the canonical `oet-project-workflow` skill plus `/pick-up` and `/ship` prompts. Without this gitignore, `git status` shows the entire `.pi/` tree as untracked on every branch, and there's a risk of accidentally committing agent material into feature branches.

`.pi/`, `.claude/`, and `AGENTS.md` are workspace-level — git leaves them untouched on `checkout`, so they persist across every branch switch automatically. No stash, no copy-paste between branches.

## Verification

```
$ git check-ignore -v .pi/
.gitignore:56:.pi/  .pi/

$ git status   # on a branch with .pi/ populated
On branch chore/gitignore-pi
nothing to commit, working tree clean
```

## Scope

Single-line gitignore change. No code touched. No issue link (this is workflow hygiene).