### PR TITLE
chore: gitignore .pi/ agent workspace (backend mirror)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ infra/
 AGENTS.md
 .mcp.json
 CLAUDE.md
+.pi/
 
 # IDEs
 .vscode/


### PR DESCRIPTION
## Summary

Mirror of #39 on the backend integration branch. Adds `.pi/` to `.gitignore` so the agent workspace directory is treated the same as `.claude/` and `AGENTS.md` — local-only, never committed.

## Why both branches need this independently

The sync direction is `dev-llm` → `dev-llm-ui` only (never the reverse). If only `dev-llm-ui` had the gitignore entry, every time `dev-llm` is merged forward the change would already be there — but `dev-llm` itself would still be missing the rule, and any backend task branch cut from `dev-llm` would show `.pi/` as untracked. Filing the same one-line change on both integration branches keeps the protection symmetric.

## Verification

```
$ git check-ignore -v .pi/
.gitignore:56:.pi/  .pi/
```

## Scope

Single-line gitignore change. No code touched. No issue link (workflow hygiene).